### PR TITLE
Add more practical use case for PyTorch hooks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,147 @@
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+*$py.class
+
+# C extensions
+*.so
+
+# Distribution / packaging
+.Python
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+wheels/
+share/python-wheels/
+*.egg-info/
+.installed.cfg
+*.egg
+MANIFEST
+
+# PyInstaller
+#  Usually these files are written by a python script from a template
+#  before PyInstaller builds the exe, so as to inject date/other infos into it.
+*.manifest
+*.spec
+
+# Installer logs
+pip-log.txt
+pip-delete-this-directory.txt
+
+# Unit test / coverage reports
+htmlcov/
+.tox/
+.nox/
+.coverage
+.coverage.*
+.cache
+nosetests.xml
+"jaylee_code_lunit_assignment/.gitignore" 160L, 3082B
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+*$py.class
+
+# C extensions
+*.so
+
+# Distribution / packaging
+.Python
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+wheels/
+share/python-wheels/
+*.egg-info/
+.installed.cfg
+*.egg
+MANIFEST
+
+# PyInstaller
+#  Usually these files are written by a python script from a template
+#  before PyInstaller builds the exe, so as to inject date/other infos into it.
+*.manifest
+*.spec
+
+# Installer logs
+pip-log.txt
+pip-delete-this-directory.txt
+
+# Unit test / coverage reports
+htmlcov/
+.tox/
+.nox/
+.coverage
+.coverage.*
+.cache
+nosetests.xml
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+*$py.class
+
+# C extensions
+*.so
+
+# Distribution / packaging
+.Python
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+wheels/
+share/python-wheels/
+*.egg-info/
+.installed.cfg
+*.egg
+MANIFEST
+
+# PyInstaller
+#  Usually these files are written by a python script from a template
+#  before PyInstaller builds the exe, so as to inject date/other infos into it.
+*.manifest
+*.spec
+
+# Installer logs
+pip-log.txt
+pip-delete-this-directory.txt
+
+# Unit test / coverage reports
+htmlcov/
+.tox/
+.nox/
+.coverage
+.coverage.*
+.cache
+nosetests.xml
+coverage.xml
+*.cover
+*.py,cover
+.hypothesis/
+.pytest_cache/
+cover/
+
+# Translations

--- a/poetry.lock
+++ b/poetry.lock
@@ -282,7 +282,7 @@ files = [
 name = "isort"
 version = "5.12.0"
 description = "A Python utility / library to sort Python imports."
-category = "main"
+category = "dev"
 optional = false
 python-versions = ">=3.8.0"
 files = [
@@ -1080,4 +1080,4 @@ test = ["pytest (>=6.0.0)"]
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.11"
-content-hash = "cfcc18db691a42a922bec8cd8f29e873972a3dd332cf062a55e909e2d34058d6"
+content-hash = "7b0784e94db083184dc2844babf9e7901110f0df703f2606ab92d64c9545aa87"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,14 +10,13 @@ packages = [{include = "pytorch_snippets"}]
 python = "^3.11"
 torch = "^2.0.0"
 torchvision = "^0.15.1"
-isort = "^5.12.0"
 
 
 [tool.poetry.group.dev.dependencies]
 pytest = "^7.2.2"
-isort = "^5.12.0"
 black = "^23.3.0"
 flake8 = "^6.0.0"
+isort = "^5.12.0"
 
 [build-system]
 requires = ["poetry-core"]

--- a/src/educational/hooks/demo.py
+++ b/src/educational/hooks/demo.py
@@ -2,25 +2,8 @@ import typing as t
 
 import torch
 import torch.nn as nn
-import torch.nn.functional as F
 
-
-class LinearModel(nn.Module):
-    def __init__(self):
-        super().__init__()
-        self.fc_1 = nn.Linear(10, 20)
-        self.fc_2 = nn.Linear(20, 30)
-        self.fc_3 = nn.Linear(30, 2)
-
-    def forward(self, input_tensor: torch.Tensor) -> torch.Tensor:
-        first_output = self.fc_1(input_tensor)
-        second_output = self.fc_2(first_output)
-        third_output = self.fc_3(second_output)
-
-        final_output = F.relu(third_output)
-        print('I should output before forward hook')
-        return final_output
-
+from src.educational.models import LinearModel
 
 if __name__ == '__main__':
     batch_size: int = 2
@@ -50,4 +33,3 @@ if __name__ == '__main__':
     model.fc_3.register_forward_hook(forward_hook_function)
 
     output = model(random_tensor)
-    print(f'Output: {output}')

--- a/src/educational/hooks/util.py
+++ b/src/educational/hooks/util.py
@@ -1,0 +1,125 @@
+import typing as t
+from collections import OrderedDict
+
+import torch
+from torch import nn
+
+from src.educational.models import LinearModel
+
+
+class ModuleNotFoundError(ValueError):
+    pass
+
+
+class HookManager:
+    def __init__(self, model: nn.Module) -> None:
+        if not isinstance(model, nn.Module):
+            raise TypeError(f'Must pass in nn.Module to "HookedModule". Found: {type(model)}')
+
+        self.model = model
+        self._forward_hooks = OrderedDict()
+        # TODO: Later add some for backward hooks
+
+    def get_module_by_name(self, target_module_name: str) -> nn.Module:
+        """Find the target nn.module by name
+
+        Args:
+            target_module_name (str): The name of the target module we are looking for
+
+        Raises:
+            ModuleNotFoundError: Occurs when module with given name cannot be found in wrapped module
+
+        Returns:
+            nn.Module: The name of
+        """
+        for name, module in self.model.named_modules():
+            if name == target_module_name:
+                return module
+
+        available_module_names = ', '.join([module_name for module_name, module in self.model.named_modules()])
+        raise ModuleNotFoundError(
+            f'Module with name: {target_module_name} not found. ' f'Available module names: {available_module_names}'
+        )
+
+    def add_forward_hook(self, module_name: str, forward_hook_function: t.Callable) -> None:
+        """Given a target module name and forward hook function,
+        add forward hook to the module with the given name
+
+        Args:
+            module_name (str): The name of the module name
+            forward_hook_function (t.Callable): The forward hook function to call (for debugging purposes)
+
+        Raises:
+            TypeError: Occurs when foward_hook_function is not callable.
+        """
+        if not isinstance(forward_hook_function, t.Callable):
+            raise TypeError('forward_hook_function must be callable. ' f'Passed in: {forward_hook_function}')
+        # Need to de-register existing hook function
+        self.remove_forward_hook(module_name)
+
+        # Retrieve module
+        module: nn.Module = self.get_module_by_name(module_name)
+
+        # Register hook
+        self._forward_hooks[module_name] = module.register_forward_hook(forward_hook_function)
+
+    def remove_forward_hook(self, module_name: str) -> None:
+        """_summary_
+
+        Args:
+            module_name (str): _description_
+
+        Raises:
+            TypeError: Occurs when the forward hook function is manipulated directly by a user,
+            resulting in the function not being callable.
+        """
+        if module_name in self._forward_hooks:
+            stored_forward_hook_function = self._forward_hooks[module_name]
+            if not isinstance(stored_forward_hook_function, torch.utils.hooks.RemovableHandle):
+                raise TypeError(
+                    f'ERROR!! forward_hook_function handle should be stored '
+                    f'instead of: {stored_forward_hook_function} of type: {type(stored_forward_hook_function)}. '
+                    'Perhaps self._forward_hooks was overriden directly.'
+                )
+            # Clean-up
+            stored_forward_hook_function.remove()
+            del self._forward_hooks[module_name]
+
+
+if __name__ == '__main__':
+    model = LinearModel()
+    hook_manager = HookManager(model)
+
+    def forward_hook_function(
+        layer: nn.Module, input_tensor: t.Tuple[torch.Tensor, ...], output_tensor: t.Tuple[torch.Tensor, ...]
+    ):
+        """
+        A hook function that is called after the forward function is processed
+
+        Args:
+            layer (nn.Module): The current layer that has registered forward hook
+            input_tensor (t.Tuple[torch.Tensor, ...]): The input arguments (*args)
+            output_tensor (t.Tuple[torch.Tensor, ...]): The output arguments (in most cases,
+                                                        a tuple with a single output tensor)
+        """
+
+        print(f'Current layer: {layer}, input_tensor: {input_tensor}' f'output tensor: {output_tensor}')
+        print('-' * 100)
+
+    hook_manager.add_forward_hook('fc_1', forward_hook_function)
+
+    # Try calling foward
+    batch_size: int = 2
+    input_shape: int = 10
+    random_tensor = torch.randn((batch_size, input_shape))
+
+    # Forward
+    output = model(random_tensor)
+    print(f'Output: {output}')
+
+    # remove hook
+    print('Removing hook!!!!!')
+    print('-----------------------')
+    hook_manager.remove_forward_hook('fc_1')
+    output = model(random_tensor)
+    print(f'Output: {output}')

--- a/src/educational/models.py
+++ b/src/educational/models.py
@@ -1,0 +1,19 @@
+import torch
+import torch.nn.functional as F
+from torch import nn
+
+
+class LinearModel(nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.fc_1 = nn.Linear(10, 20)
+        self.fc_2 = nn.Linear(20, 30)
+        self.fc_3 = nn.Linear(30, 2)
+        self.relu = lambda x: F.relu(x)
+
+    def forward(self, input_tensor: torch.Tensor) -> torch.Tensor:
+        first_output = self.fc_1(input_tensor)
+        second_output = self.fc_2(first_output)
+        third_output = self.fc_3(second_output)
+        final_output = self.relu(third_output)
+        return final_output


### PR DESCRIPTION
## As Is 

- Simple demo showcasing wrapper classes does not exist
- No `.gitignore`

## To Be

- Added simple demo showcase of a basic utility class that maintains the state of the forward hooks
- Add `.gitignore`